### PR TITLE
Add a `busy` flag to leases.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firelease",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Firebase queue consumer for Node with at-least-once semantics",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We seem to be running into "reset / delete existing task" scenarios more and more frequently, so I think it makes sense to add a (best-effort) flag for "is it safe to tweak the lease or not".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/firelease/14)
<!-- Reviewable:end -->
