### PR TITLE
Automatically recover from failure to load a queue's tasks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firelease",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Firebase queue consumer for Node with at-least-once semantics",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When a queue gets way too large (likely because it wasn't being serviced while tasks kept getting added) it can fail in one of two ways:
1. The Firebase server can refuse the data request altogether.  This causes an immediate disconnection, logs an internal Firebase error (but does _not_ report it to the client!), and reconnects with all outstanding listeners still present.  This causes a connect/disconnect loop that a client won't normally recover from.
2. The queue data is not large enough to trigger the scenario above, but still so large that it blocks other processing by DoS'ing the Firebase connection.  This results in tons of timeouts and, again, prevents the server from making progress.

In this change I added code to detect when Firebase disconnects while we're waiting for a queue's tasks to load in, and also to force a disconnect if a queue takes too long to load.  Either of these will put the queue into failsafe mode where it only loads 5 items at a time, and tries to exit failsafe mode every 1-2 minutes (to avoid potentially having all servers try it at the same time).  The 5 items at a time query mode is known to have issues (bandwidth usage and missing updates) but it's the only thing that will work when the queue is too large, and we only use it until we can resume normal mode again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/firelease/16)
<!-- Reviewable:end -->
