### PR TITLE
Support multi-source logical queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ than zero, to properly balance task distribution between the processes.
   in Firebase.  When multiple refs are supplied, their tasks form one logical queue: they use the
   same worker and share `maxConcurrent`, `leaseDelay`, and the other queue options.  The refs may
   point to different paths and databases.  Individual tasks will be children of these roots and
-  must be objects.  The `_lease` key is reserved for use by Firelease in each task.
+  must be objects.  Duplicate refs in the same array are ignored; as with the single-ref API, don't
+  attach separate logical queues to the same path in one process.  The `_lease` key is reserved for
+  use by Firelease in each task.
 
 * `@param {Object} options` Optional options, supporting the following values:
   * `maxConcurrent: {number}` max number of tasks to handle concurrently for this worker.
@@ -74,8 +76,10 @@ Sets up regular pinging of all queues.  Can be called either before or after wor
 and will always ping all queues.  Can be called more than once to change the parameters.
 
 * `@param {Function(Object) | null} callback` The callback to invoke with a report each time we ping
-  all the queues.  The report looks like: `{healthy: true, maxLatency: 1234}`.  If not
-  specified, reports are silently dropped.
+  all the queues.  The report looks like:
+  `{healthy: true, maxLatency: 1234, sickQueues: [], sickSources: []}`.  `sickQueues` contains
+  logical queue keys, while `sickSources` contains the full URLs of unhealthy physical sources.  If
+  not specified, reports are silently dropped.
 
 * `@param {number | string} interval` The interval at which to ping queues, to both check the
   current response latency and make sure no tasks are stuck.  Defaults to 1 minute.

--- a/README.md
+++ b/README.md
@@ -14,23 +14,25 @@ To use generators, make sure to set `Promise.co` to a `co`-compatible function.
 
 The module exposes these functions:
 
-```function attachWorker(ref, options, worker)```
+```function attachWorker(refOrRefs, options, worker)```
 
 Attaches a worker function to consume tasks from a queue.  You should normally attach no more
 than one worker per path in any given process, but it's OK to run multiple processes on the same
 paths concurrently.  If you do, you probably want to set `maxLeaseDelay` to something greater
 than zero, to properly balance task distribution between the processes.
 
-* `@param {Nodefire} ref` A Nodefire ref to the queue root in Firebase.  Individual tasks will be
-  children of this root and must be objects.  The `_lease` key is reserved for use by
-  Firelease in each task.
+* `@param {Nodefire | Nodefire[]} refOrRefs` A Nodefire ref, or an array of refs, to the queue roots
+  in Firebase.  When multiple refs are supplied, their tasks form one logical queue: they use the
+  same worker and share `maxConcurrent`, `leaseDelay`, and the other queue options.  The refs may
+  point to different paths and databases.  Individual tasks will be children of these roots and
+  must be objects.  The `_lease` key is reserved for use by Firelease in each task.
 
 * `@param {Object} options` Optional options, supporting the following values:
   * `maxConcurrent: {number}` max number of tasks to handle concurrently for this worker.
-  * `bufferSize: {number}` upper bound on how many tasks to keep buffered and potentially go through
-    leasing transactions in parallel.  In principle, it's not worth setting higher than
-    `maxConcurrent`, but you can set it to `Infinity` to keep the entire task queue buffered at all
-    times if needed.
+  * `bufferSize: {number}` upper bound on how many tasks to keep buffered from each source and
+    potentially go through leasing transactions in parallel.  In principle, it's not worth setting
+    higher than `maxConcurrent`, but you can set it to `Infinity` to keep the entire task queue
+    buffered at all times if needed.
   * `minLease: {number | string}` minimum duration of each lease, which should equal the maximum
     expected time a worker will take to handle a task.
   * `maxLease: {number | string}` maximum duration of each lease; the lease duration is doubled each

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import reviewableConfigBaseline from 'reviewable-configs/eslint-config/baseline.
 export default [
   ...reviewableConfigBaseline,
   {
-    files: ['*.js'],
+    files: ['*.js', 'tests/*.js'],
     languageOptions: {
       globals: {
         ...globals.node,

--- a/firelease.js
+++ b/firelease.js
@@ -364,9 +364,9 @@ class Queue {
       worker = options;
       options = {};
     }
-    const refs = _.isArray(refOrRefs) ? refOrRefs : [refOrRefs];
+    const refs = _(refOrRefs).castArray().uniqBy(item => item.toString()).value();
     if (!refs.length) throw new Error('At least one queue ref is required');
-    this.refs = _.uniqBy(refs, item => item.toString());
+    this.refs = refs;
     this.ref = this.refs[0];
     this.options = _.defaults({}, options, module.exports.defaults);
     this.options.minLease = duration(this.options.minLease);

--- a/firelease.js
+++ b/firelease.js
@@ -155,7 +155,7 @@ class Task {
     Object.defineProperty(item, '$ref', {value: this.ref});
     Object.defineProperty(item, '$leaseTimeRemaining', {get: () => {
       if (!(item._lease && item._lease.expiry)) return 0;
-      return Math.max(0, item._lease.expiry - this.queue.now);
+      return Math.max(0, item._lease.expiry - this.ref.now);
     }});
     this.phase = 'work';
     return this.queue.callWorker(item).finally(() => {
@@ -532,8 +532,10 @@ let pingIntervalHandle, pingCallback;
  * All durations can be specified as either a human-readable string, or a number of milliseconds.
  *
  * @param {Function(Object) | null} callback The callback to invoke with a report each time we ping
- *        all the queues.  The report looks like: {healthy: true, maxLatency: 1234}.  If not
- *        specified, reports are silently dropped.
+ *        all the queues.  The report looks like:
+ *        {healthy: true, maxLatency: 1234, sickQueues: [], sickSources: []}.  sickQueues contains
+ *        logical queue keys, while sickSources contains the full URLs of unhealthy physical
+ *        sources.  If not specified, reports are silently dropped.
  * @param {number | string} interval The interval at which to ping queues, to both check the
  *        current response latency and make sure no tasks are stuck.  Defaults to 1 minute.
  */
@@ -565,8 +567,8 @@ function checkPings() {
       if (!pingFree) return null;  // another process is currently pinging
       return waitUntilDeleted(pingRef, queue.options.healthyPingLatency + ms('10s')).then(() => {
         const latency = Date.now() - start;
-        return {latency, healthy: latency < queue.options.healthyPingLatency};
-      }, () => null);
+        return {source, latency, healthy: latency < queue.options.healthyPingLatency};
+      }, () => ({source, latency: Date.now() - start, healthy: false}));
     });
   })).then(sourceResults => {
     sourceResults = _.compact(sourceResults);
@@ -575,6 +577,7 @@ function checkPings() {
       queue,
       latency: _.max(_.map(sourceResults, 'latency')),
       healthy: _.every(sourceResults, 'healthy'),
+      sickSources: _(sourceResults).reject('healthy').map('source').value(),
       leaseDelay: queue.leaseDelay,
       tasksAcquired: queue.tasksAcquired
     };
@@ -586,6 +589,11 @@ function checkPings() {
       if (pingCallback) {
         const sickQueueKeys =
           _(results).reject('healthy').map(item => item.queue.ref.key).value();
+        const sickSourceUrls = _(results)
+          .flatMap(result => result.sickSources)
+          .map(source => source.ref.toString())
+          .uniq()
+          .value();
         const delays = _(results).map('leaseDelay').sortBy().value();
         const delaysMedian = delays.length % 2 ?
           delays[Math.floor(delays.length / 2)] :
@@ -594,6 +602,7 @@ function checkPings() {
         pingCallback({
           healthy: _.every(results, 'healthy'),
           sickQueues: sickQueueKeys,
+          sickSources: sickSourceUrls,
           stuckTasks: blacklistedTaskKeys.size,
           maxLatency: _.max(_.map(results, 'latency')),
           tasksAcquired: _.reduce(results, (sum, result) => sum + result.tasksAcquired, 0),
@@ -692,7 +701,7 @@ module.exports.blacklist = function(taskKey) {
   if (blacklistedTaskKeys.has(taskKey)) return false;
   blacklistedTaskKeys.add(taskKey);
   const task = tasks[taskKey];
-  if (task) task.queue.removeTask(taskKey);
+  if (task) task.source.removeTask(taskKey);
   return true;
 };
 

--- a/firelease.js
+++ b/firelease.js
@@ -65,8 +65,9 @@ module.exports.captureError = error => {console.log(error.stack);};
 
 
 class Task {
-  constructor(queue, snap) {
-    this.queue = queue;
+  constructor(source, snap) {
+    this.source = source;
+    this.queue = source.queue;
     this.ref = snap.ref;
     this.key = Task.makeKey(snap);
     this.phase = 'wait';
@@ -79,14 +80,14 @@ class Task {
 
   updateFrom(snap) {
     const value = snap.val();
-    this.expiry = value && value._lease && value._lease.expiry || this.queue.now;
+    this.expiry = value && value._lease && value._lease.expiry || this.ref.now;
     // console.log('update', this.key, 'expiry', this.expiry);
     delete this.removed;
   }
 
   prepare() {
     if (tasks[this.key] !== this || this.removed || this.working) return false;
-    const now = this.queue.now;
+    const now = this.ref.now;
     const busy = this.expiry + this.queue.leaseDelay > now;
     // console.log('prepare', this.ref.key, 'expiry', this.expiry, 'now', now);
     if (!busy) {
@@ -112,7 +113,7 @@ class Task {
         acquired = true;
         return null;
       }
-      startTimestamp = this.queue.now;
+      startTimestamp = this.ref.now;
       // console.log('txn  ', this.ref.key, 'lease', item._lease, 'now', startTimestamp);
       // Check if another process beat us to it.
       if (item._lease && item._lease.expiry &&
@@ -139,7 +140,7 @@ class Task {
       // Hardcoded retry -- hard to do anything smarter, since we failed to update the task in
       // Firebase.
       this.expiry = 0;
-      if (/timeout/i.test(error.message) && !this.queue.connected) return;
+      if (/timeout/i.test(error.message) && !this.source.connected) return;
       console.log(`Queue item ${this.key} lease transaction error: ${error.message}`);
       error.firelease = _.assign(error.firelease || {}, {itemKey: this.key, phase: 'leasing'});
       module.exports.captureError(error);
@@ -158,7 +159,7 @@ class Task {
     }});
     this.phase = 'work';
     return this.queue.callWorker(item).finally(() => {
-      const now = this.queue.now;
+      const now = this.ref.now;
       if (now > item._lease.expiry) {
         this.phase = 'exceed';
         // If it looks like we exceeded the lease time, double-check against the current item before
@@ -206,7 +207,7 @@ class Task {
         if (item2) item._lease = item2._lease;
       });
     }, error => {
-      if (/timeout/i.test(error.message) && !this.queue.connected) return;
+      if (/timeout/i.test(error.message) && !this.source.connected) return;
       console.log(`Queue item ${this.key} processing error: ${error.message}`);
       error.firelease = _.assign(error.firelease || {}, {itemKey: this.key, phase: 'processing'});
       if (!error.level) error.level = 'warning';
@@ -215,7 +216,7 @@ class Task {
       // whether another handler has already picked up the task so leave it be.
       if (this.phase !== 'exceed') return this.ref.child('_lease/busy').set(null);
     }).catch(error => {
-      if (/timeout/i.test(error.message) && !this.queue.connected) return;
+      if (/timeout/i.test(error.message) && !this.source.connected) return;
       console.log(`Queue item ${this.key} post-processing error: ${error.message}`);
       error.firelease =
         _.assign(error.firelease || {}, {itemKey: this.key, phase: 'post-processing'});
@@ -225,34 +226,20 @@ class Task {
 }
 
 
-class Queue {
-  constructor(ref, options, worker) {
-    if (_.isFunction(options)) {
-      worker = options;
-      options = {};
-    }
-    this.options = _.defaults({}, options, module.exports.defaults);
-    this.options.minLease = duration(this.options.minLease);
-    this.options.maxLease = duration(this.options.maxLease);
-    this.options.minLeaseDelay = this.leaseDelay = duration(this.options.leaseDelay);
-    delete this.options.leaseDelay;
-    this.options.healthyPingLatency = duration(this.options.healthyPingLatency);
-    this.options.maxLeaseDelay = duration(this.options.maxLeaseDelay);
-    this.numConcurrent = 0;
-    this.tasksAcquired = 0;
-    this.worker = worker;
+class QueueSource {
+  constructor(queue, ref) {
+    this.queue = queue;
     this.ref = ref;
     this.topRef = undefined;
     this.mode = 'initial';  // one of 'initial', 'normal', 'failed', 'failsafe', 'recovery'
     this.epoch = 0;
     this.connected = false;
+  }
 
-    // Need each queue's scan function to be debounced separately.
-    this.scan = _.debounce(this.scan.bind(this), 100);
-
+  start() {
     this.listen();
 
-    ref.root.child('.info/connected').on('value', snap => {
+    this.ref.root.child('.info/connected').on('value', snap => {
       if (this.connected === snap.val()) return;
       this.connected = snap.val();
       if (this.connected) {
@@ -260,14 +247,15 @@ class Queue {
         // the server.
         _.delay(() => {
           if (!this.connected) return;
-          this.scan();
+          this.queue.scan();
         }, ms('5s'));
       } else {
         this.epoch += 1;
         const failed =
           (this.mode === 'initial' || this.mode === 'recovery') &&
-          !_.some(
-            queues, queue => queue.mode === 'failed' && queue.ref.root.isEqual(this.ref.root));
+          !_.some(queues, queue => _.some(
+            queue.sources,
+            source => source.mode === 'failed' && source.ref.root.isEqual(this.ref.root)));
         if (failed) {
           if (this.mode === 'initial') {
             console.log(`Queue worker ${this.ref} failed to load tasks, entering failsafe mode`);
@@ -298,11 +286,11 @@ class Queue {
       this.topRef.off(
         this.topRef === this.ref ? 'child_changed' : 'child_moved', this.addTask, this);
       _.forEach(tasks, (task, taskKey) => {
-        if (task.queue === this) this.removeTask(taskKey);
+        if (task.source === this) this.removeTask(taskKey);
       });
     }
 
-    let bufferSize = this.options.bufferSize;
+    let bufferSize = this.queue.options.bufferSize;
     if (failsafe) bufferSize = Math.min(bufferSize, 5);
     const bufferAll = bufferSize === Infinity;
     this.topRef =
@@ -331,12 +319,6 @@ class Queue {
     }
   }
 
-  scan() {
-    _.forEach(tasks, task => {
-      if (task.queue === this) task.queue.process(task);
-    });
-  }
-
   crash(error) {
     console.log(`Queue worker ${this.ref} interrupted:`, error.message);
     error.firelease =
@@ -345,10 +327,6 @@ class Queue {
     // Give the error capture a chance to process before exiting.
     _.delay(() => {process.exit(1);}, ms('3s'));
 
-  }
-
-  get now() {
-    return this.ref.now;
   }
 
   addTask(snap) {
@@ -363,19 +341,57 @@ class Queue {
     } else {
       task = tasks[taskKey] = new Task(this, snap);
     }
-    this.process(task);
+    this.queue.process(task);
   }
 
   removeTask(snapOrKey) {
     const taskKey = typeof snapOrKey === 'string' ? snapOrKey : Task.makeKey(snapOrKey);
     const task = tasks[taskKey];
-    if (!task) return;
+    if (!task || task.source !== this) return;
     task.removed = true;
     if (task.timeout) {
       task.timeout.clear();
       delete task.timeout;
     }
     if (!task.working) delete tasks[taskKey];
+  }
+}
+
+
+class Queue {
+  constructor(refOrRefs, options, worker) {
+    if (_.isFunction(options)) {
+      worker = options;
+      options = {};
+    }
+    const refs = _.isArray(refOrRefs) ? refOrRefs : [refOrRefs];
+    if (!refs.length) throw new Error('At least one queue ref is required');
+    this.refs = _.uniqBy(refs, item => item.toString());
+    this.ref = this.refs[0];
+    this.options = _.defaults({}, options, module.exports.defaults);
+    this.options.minLease = duration(this.options.minLease);
+    this.options.maxLease = duration(this.options.maxLease);
+    this.options.minLeaseDelay = this.leaseDelay = duration(this.options.leaseDelay);
+    delete this.options.leaseDelay;
+    this.options.healthyPingLatency = duration(this.options.healthyPingLatency);
+    this.options.maxLeaseDelay = duration(this.options.maxLeaseDelay);
+    this.numConcurrent = 0;
+    this.tasksAcquired = 0;
+    this.worker = worker;
+    this.sources = _.map(this.refs, sourceRef => new QueueSource(this, sourceRef));
+
+    // Need each queue's scan function to be debounced separately.
+    this.scan = _.debounce(this.scan.bind(this), 100);
+  }
+
+  start() {
+    _.forEach(this.sources, source => {source.start();});
+  }
+
+  scan() {
+    _.forEach(tasks, task => {
+      if (task.queue === this) this.process(task);
+    });
   }
 
   hasQuota() {
@@ -396,7 +412,7 @@ class Queue {
   }
 
   process(task) {
-    if (this.connected && this.hasQuota() && task.prepare()) {
+    if (task.source.connected && this.hasQuota() && task.prepare()) {
       globalNumConcurrent++;
       this.numConcurrent++;
       task.process().then(() => {
@@ -448,15 +464,16 @@ class Queue {
  *
  * All durations can be specified as either a human-readable string, or a number of milliseconds.
  *
- * @param {NodeFire} ref A NodeFire ref to the queue root in Firebase.  Individual tasks will be
- *        children of this root and must be objects.  The '_lease' key is reserved for use by
- *        Firelease in each task.
+ * @param {NodeFire | NodeFire[]} refOrRefs One or more NodeFire refs to queue roots in Firebase.
+ *        Individual tasks will be children of these roots and must be objects.  All refs form one
+ *        logical queue and share the same worker and concurrency limits.  The '_lease' key is
+ *        reserved for use by Firelease in each task.
  * @param {Object} options Optional options, supporting the following values:
  *        maxConcurrent: {number} max number of tasks to handle concurrently for this worker.
- *        bufferSize: {number} upper bound on how many tasks to keep buffered and potentially go
- *          through leasing transactions in parallel.  In principle, it's not worth setting higher
- *          than `maxConcurrent`, but you can set it to `Infinity` to keep the entire task queue
- *          buffered at all times if needed.
+ *        bufferSize: {number} upper bound on how many tasks to keep buffered from each source and
+ *          potentially go through leasing transactions in parallel.  In principle, it's not worth
+ *          setting higher than `maxConcurrent`, but you can set it to `Infinity` to keep the entire
+ *          task queue buffered at all times if needed.
  *        minLease: {number | string} minimum duration of each lease, which should equal the maximum
  *          expected time a worker will take to handle a task.
  *        maxLease: {number | string} maximum duration of each lease; the lease duration is doubled
@@ -492,8 +509,10 @@ class Queue {
  *        All of these values can also be wrapped in a promise or a generator, which will be dealt
  *        with appropriately.
  */
-module.exports.attachWorker = function(ref, options, worker) {
-  queues.push(new Queue(ref, options, worker));
+module.exports.attachWorker = function(refOrRefs, options, worker) {
+  const queue = new Queue(refOrRefs, options, worker);
+  queues.push(queue);
+  queue.start();
 };
 
 function duration(value) {
@@ -535,9 +554,9 @@ module.exports.pingQueues = function(callback, interval) {
 function checkPings() {
   if (pinging) return Promise.resolve();
   pinging = true;
-  return Promise.all(_.map(queues, queue => {
+  return Promise.all(_.map(queues, queue => Promise.all(_.map(queue.sources, source => {
     const start = Date.now();
-    const pingRef = queue.ref.child(PING_KEY);
+    const pingRef = source.ref.child(PING_KEY);
     let pingFree;
     return pingRef.transaction(item => {
       pingFree = !item;
@@ -546,13 +565,20 @@ function checkPings() {
       if (!pingFree) return null;  // another process is currently pinging
       return waitUntilDeleted(pingRef, queue.options.healthyPingLatency + ms('10s')).then(() => {
         const latency = Date.now() - start;
-        return {
-          queue, latency, healthy: latency < queue.options.healthyPingLatency,
-          leaseDelay: queue.leaseDelay, tasksAcquired: queue.tasksAcquired
-        };
+        return {latency, healthy: latency < queue.options.healthyPingLatency};
       }, () => null);
     });
-  })).then(results => {
+  })).then(sourceResults => {
+    sourceResults = _.compact(sourceResults);
+    if (!sourceResults.length) return null;
+    return {
+      queue,
+      latency: _.max(_.map(sourceResults, 'latency')),
+      healthy: _.every(sourceResults, 'healthy'),
+      leaseDelay: queue.leaseDelay,
+      tasksAcquired: queue.tasksAcquired
+    };
+  }))).then(results => {
     results = _.compact(results);
     if (results.length) {
       // Backup scan in case tasks are stuck on a queue due to bugs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firelease",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "packageManager": "yarn@4.13.0",
   "description": "Firebase queue consumer for Node with at-least-once semantics",
   "main": "index.js",
@@ -8,7 +8,8 @@
     "update": "yarn up -R '*' && yarn dedupe --strategy highest",
     "latest": "yarn npm-check-updates -i -m --packageManager yarn --install never && yarn install",
     "upgrade": "reviewable-upgrade",
-    "lint": "eslint *.js"
+    "lint": "eslint *.js tests/*.js",
+    "test": "node tests/multiple_sources.test.js"
   },
   "repository": "https://github.com/Reviewable/firelease",
   "keywords": [

--- a/tests/multiple_sources.test.js
+++ b/tests/multiple_sources.test.js
@@ -180,6 +180,11 @@ function waitFor(predicate, timeout = 2000) {
 
 
 async function run() {
+  assert.throws(
+    () => {firelease.attachWorker([], () => {/* Do nothing. */});},
+    /At least one queue ref is required/
+  );
+
   const firstSource = new FakeQueueRef('first-database', 'queues/jobs');
   const secondSource = new FakeQueueRef('second-database', 'other/jobs');
   const calls = [];

--- a/tests/multiple_sources.test.js
+++ b/tests/multiple_sources.test.js
@@ -183,6 +183,7 @@ async function run() {
   const firstSource = new FakeQueueRef('first-database', 'queues/jobs');
   const secondSource = new FakeQueueRef('second-database', 'other/jobs');
   const calls = [];
+  const leaseTimesRemaining = [];
   let active = 0;
   let maxActive = 0;
   let releaseFirst;
@@ -195,6 +196,7 @@ async function run() {
       active++;
       maxActive = Math.max(maxActive, active);
       calls.push(item.$ref.toString());
+      leaseTimesRemaining.push(item.$leaseTimeRemaining);
       if (calls.length === 1) {
         return firstBlocked.then(() => {active--;});
       }
@@ -204,9 +206,12 @@ async function run() {
 
   const firstTask = firstSource.addTask('task', {payload: 1});
   const secondTask = secondSource.addTask('task', {payload: 2});
+  const blacklistedTask = secondSource.addTask('blacklisted', {payload: 3});
 
   await waitFor(() => calls.length === 1);
   assert.deepStrictEqual(firelease.listTasksInProgress(), [firstTask.toString()]);
+  assert.strictEqual(firelease.blacklist(blacklistedTask.toString()), true);
+  assert.strictEqual(firelease.blacklist(blacklistedTask.toString()), false);
   await new Promise(resolve => {setTimeout(resolve, 50);});
   assert.strictEqual(calls.length, 1, 'logical maxConcurrent must cover every source');
 
@@ -214,6 +219,8 @@ async function run() {
   await waitFor(() => calls.length === 2 && !firstTask.value && !secondTask.value);
 
   assert.deepStrictEqual(calls, [firstTask.toString(), secondTask.toString()]);
+  assert(leaseTimesRemaining.every(Number.isFinite));
+  assert(leaseTimesRemaining.every(time => time > 0));
   assert.strictEqual(maxActive, 1);
   assert.deepStrictEqual(firelease.listTasksInProgress(), []);
 
@@ -221,10 +228,21 @@ async function run() {
   let legacyTaskUrl;
   firelease.attachWorker(legacySource, item => {
     legacyTaskUrl = item.$ref.toString();
+    assert(Number.isFinite(item.$leaseTimeRemaining));
   });
   const legacyTask = legacySource.addTask('task', {payload: 3});
   await waitFor(() => legacyTaskUrl && !legacyTask.value);
   assert.strictEqual(legacyTaskUrl, legacyTask.toString());
+
+  const duplicateSource = new FakeQueueRef('duplicate-database', 'queues/duplicate');
+  let duplicateTaskUrl;
+  firelease.attachWorker([duplicateSource, duplicateSource], {bufferSize: Infinity}, item => {
+    duplicateTaskUrl = item.$ref.toString();
+  });
+  assert.strictEqual(duplicateSource.listeners.child_added.length, 1);
+  const duplicateTask = duplicateSource.addTask('task', {payload: 4});
+  await waitFor(() => duplicateTaskUrl && !duplicateTask.value);
+  assert.strictEqual(duplicateTaskUrl, duplicateTask.toString());
 }
 
 

--- a/tests/multiple_sources.test.js
+++ b/tests/multiple_sources.test.js
@@ -1,0 +1,234 @@
+'use strict';
+
+const assert = require('assert');
+const firelease = require('..');
+
+
+class FakeSnapshot {
+  constructor(ref) {
+    this.ref = ref;
+  }
+
+  val() {
+    return clone(this.ref.value);
+  }
+}
+
+
+class FakeDatabaseRoot {
+  constructor(name) {
+    this.name = name;
+    this.database = {
+      app: {name},
+      goOffline() {/* Do nothing. */},
+      goOnline() {/* Do nothing. */}
+    };
+  }
+
+  child(path) {
+    assert.strictEqual(path, '.info/connected');
+    return {
+      on: (event, callback, cancelCallback, context) => {
+        assert.strictEqual(event, 'value');
+        callback.call(context, {val: () => true});
+      }
+    };
+  }
+
+  isEqual(other) {
+    return other === this;
+  }
+}
+
+
+class FakeTaskRef {
+  constructor(queueRef, key) {
+    this.queueRef = queueRef;
+    this.key = key;
+    this.value = null;
+  }
+
+  get root() {
+    return this.queueRef.root;
+  }
+
+  get database() {
+    return this.queueRef.database;
+  }
+
+  get now() {
+    return this.queueRef.now;
+  }
+
+  toString() {
+    return `${this.queueRef}/${this.key}`;
+  }
+
+  transaction(update) {
+    const updated = update(clone(this.value));
+    if (updated !== undefined) this.value = clone(updated);
+    return Promise.resolve(clone(this.value));
+  }
+
+  get() {
+    return Promise.resolve(clone(this.value));
+  }
+
+  remove() {
+    this.value = null;
+    this.queueRef.emit('child_removed', new FakeSnapshot(this));
+    return Promise.resolve();
+  }
+
+  child(path) {
+    return {
+      set: value => {
+        if (path === '_lease/busy' && this.value && this.value._lease) {
+          this.value._lease.busy = value;
+        }
+        return Promise.resolve();
+      }
+    };
+  }
+}
+
+
+class FakeQueueRef {
+  constructor(databaseName, path) {
+    this.databaseRoot = new FakeDatabaseRoot(databaseName);
+    this.database = this.databaseRoot.database;
+    this.path = path;
+    this.key = path.split('/').pop();
+    this.listeners = {};
+    this.tasks = {};
+  }
+
+  get root() {
+    return this.databaseRoot;
+  }
+
+  get now() {
+    return Date.now();
+  }
+
+  toString() {
+    return `https://${this.databaseRoot.name}.example.test/${this.path}`;
+  }
+
+  orderByChild(path) {
+    assert.strictEqual(path, '_lease/expiry');
+    return this;
+  }
+
+  limitToFirst() {
+    return this;
+  }
+
+  get() {
+    return Promise.resolve(null);
+  }
+
+  child(key) {
+    if (!this.tasks[key]) this.tasks[key] = new FakeTaskRef(this, key);
+    return this.tasks[key];
+  }
+
+  on(event, callback, cancelCallback, context) {
+    this.listeners[event] = this.listeners[event] || [];
+    this.listeners[event].push({callback, context});
+  }
+
+  off(event, callback, context) {
+    this.listeners[event] = (this.listeners[event] || []).filter(
+      listener => listener.callback !== callback || listener.context !== context);
+  }
+
+  addTask(key, value) {
+    const ref = this.child(key);
+    ref.value = clone(value);
+    this.emit('child_added', new FakeSnapshot(ref));
+    return ref;
+  }
+
+  emit(event, snapshot) {
+    for (const listener of this.listeners[event] || []) {
+      listener.callback.call(listener.context, snapshot);
+    }
+  }
+}
+
+
+function clone(value) {
+  return value === null || value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function waitFor(predicate, timeout = 2000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    function check() {
+      if (predicate()) {
+        resolve();
+      } else if (Date.now() - start >= timeout) {
+        reject(new Error('Timed out waiting for condition'));
+      } else {
+        setTimeout(check, 10);
+      }
+    }
+    check();
+  });
+}
+
+
+async function run() {
+  const firstSource = new FakeQueueRef('first-database', 'queues/jobs');
+  const secondSource = new FakeQueueRef('second-database', 'other/jobs');
+  const calls = [];
+  let active = 0;
+  let maxActive = 0;
+  let releaseFirst;
+  const firstBlocked = new Promise(resolve => {releaseFirst = resolve;});
+
+  firelease.attachWorker(
+    [firstSource, secondSource],
+    {bufferSize: Infinity, maxConcurrent: 1, minLease: '1s'},
+    item => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      calls.push(item.$ref.toString());
+      if (calls.length === 1) {
+        return firstBlocked.then(() => {active--;});
+      }
+      active--;
+    }
+  );
+
+  const firstTask = firstSource.addTask('task', {payload: 1});
+  const secondTask = secondSource.addTask('task', {payload: 2});
+
+  await waitFor(() => calls.length === 1);
+  assert.deepStrictEqual(firelease.listTasksInProgress(), [firstTask.toString()]);
+  await new Promise(resolve => {setTimeout(resolve, 50);});
+  assert.strictEqual(calls.length, 1, 'logical maxConcurrent must cover every source');
+
+  releaseFirst();
+  await waitFor(() => calls.length === 2 && !firstTask.value && !secondTask.value);
+
+  assert.deepStrictEqual(calls, [firstTask.toString(), secondTask.toString()]);
+  assert.strictEqual(maxActive, 1);
+  assert.deepStrictEqual(firelease.listTasksInProgress(), []);
+
+  const legacySource = new FakeQueueRef('legacy-database', 'queues/legacy');
+  let legacyTaskUrl;
+  firelease.attachWorker(legacySource, item => {
+    legacyTaskUrl = item.$ref.toString();
+  });
+  const legacyTask = legacySource.addTask('task', {payload: 3});
+  await waitFor(() => legacyTaskUrl && !legacyTask.value);
+  assert.strictEqual(legacyTaskUrl, legacyTask.toString());
+}
+
+
+run().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- allow `attachWorker` to accept either one NodeFire ref or an array of refs
- combine tasks from multiple paths or Firebase databases into one logical queue with shared worker, concurrency, lease-delay, shutdown, and metrics state
- keep connection, listener, timestamp, and failsafe recovery state scoped to each physical source
- aggregate health pings once per logical queue while checking every source
- document per-source buffering, add cross-database regression coverage, and bump the package version to 3.4.0

## Why

Some workloads need to migrate or partition a queue across multiple Firebase locations without creating independent concurrency domains. Treating those locations as one logical queue preserves the existing worker contract and global queue behavior while allowing storage to be split across paths or databases.

The existing single-ref API remains supported unchanged, and each task still exposes its actual source through `$ref`.

## Validation

- `yarn install --immutable`
- `yarn test`
- `yarn lint`
- `node --check firelease.js`
- `git diff --check`
- `npm pack --dry-run --json`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/firelease/18)
<!-- Reviewable:end -->
