### PR TITLE
Fix extendLease test timing race

### DIFF
--- a/tests/multiple_sources.test.ts
+++ b/tests/multiple_sources.test.ts
@@ -114,6 +114,7 @@ class FakeQueueRef {
   readonly key: string;
   readonly listeners: Record<string, Listener[]> = {};
   readonly tasks: Record<string, FakeTaskRef> = {};
+  fixedNow?: number;
 
   constructor(databaseName: string, readonly path: string) {
     this.databaseRoot = new FakeDatabaseRoot(databaseName);
@@ -126,7 +127,7 @@ class FakeQueueRef {
   }
 
   get now() {
-    return Date.now();
+    return this.fixedNow ?? Date.now();
   }
 
   toString() {
@@ -279,14 +280,16 @@ async function run() {
   assert.strictEqual(duplicateTaskUrl, duplicateTask.toString());
 
   const extensionSource = new FakeQueueRef('extension-database', 'queues/extension');
+  // Exercise the exact-boundary path where the first extension already satisfies the second.
+  extensionSource.fixedNow = Date.now();
   let extensionComplete = false;
   firelease.attachWorker(asNodeFire(extensionSource), {minLease: '1s'}, async item => {
-    const initialExpiry = item._lease.expiry;
     const firstExtension = firelease.extendLease(item, '2s');
+    const secondExtensionTimestamp = item.$ref.now;
     const secondExtension = firelease.extendLease(item, '3s');
     assert.strictEqual(firstExtension, secondExtension);
     await firstExtension;
-    assert(item._lease.expiry >= initialExpiry + 5000);
+    assert(item._lease.expiry >= secondExtensionTimestamp + 3000);
     extensionComplete = true;
   });
   const extensionTask = extensionSource.addTask('task', {payload: 5});
@@ -301,5 +304,5 @@ function asNodeFire(ref: FakeQueueRef) {
 
 void run().catch(error => {
   console.error(error);
-  process.exitCode = 1;
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary

- freeze the fake queue clock in the concurrent lease-extension test so the exact-boundary early-abort path is exercised deterministically
- assert the documented three-second minimum remaining lease from the second request instead of incorrectly requiring both extensions to be additive
- terminate the standalone test process after reporting a failure so Firelease retry timers cannot leave GitHub Actions running indefinitely

## Root cause

With a 1-second initial lease, the first 2-second extension can leave exactly 3 seconds remaining. On a fast runner the concurrent 3-second request correctly observes that its requirement is already satisfied, while the previous assertion expected another 3 seconds to be added. When that assertion failed, Firelease retained and retried the task, and the harness only set `process.exitCode`, leaving retry timers alive.

## Validation

- `yarn test`
- `yarn check-types`
- `yarn lint`
- `yarn build`
- `yarn pack --dry-run`
- `git -c core.whitespace=cr-at-eol diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/firelease/20)
<!-- Reviewable:end -->
