### PR TITLE
Bound queue check cooldowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firelease",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "packageManager": "yarn@4.13.0",
   "description": "Firebase queue consumer for Node with at-least-once semantics",
   "main": "built/index.js",

--- a/src/firelease.ts
+++ b/src/firelease.ts
@@ -6,11 +6,12 @@ import {
   FireleaseStats, QueueSourceStats, QueueStats, type QueueSourceMode
 } from './stats';
 
-export const TESTABLES = {resetBetweenTests, waitUntilDeleted};
+export const TESTABLES = {resetBetweenTests, waitUntilDeleted, getQueueCheckCooldown};
 
 const PING_INTERVAL = ms('1m');
 const PING_KEY = 'ping';
 const QUEUE_CHECK_TIMEOUT = ms('15s');
+const MAX_QUEUE_CHECK_COOLDOWN = ms('30s');
 const QUEUE_SIZE_HYSTERESIS = 0.15;
 const QUEUE_SIZE_MISMATCH_THRESHOLD = 100;
 const DEMOTION_JITTER = ms('30s');
@@ -478,14 +479,16 @@ interface QueueCheckJob {
 
 type QueueLoadResult = 'loaded' | 'stopped' | 'timed-out';
 
+function getQueueCheckCooldown(previousDuration: number) {
+  return Math.min(previousDuration, MAX_QUEUE_CHECK_COOLDOWN);
+}
+
 class QueueCheckQueue {
   jobs: QueueCheckJob[] = [];
   active?: QueueCheckJob;
   draining = false;
   previousDuration = 0;
   previousFinishedAt = 0;
-  cooldownTimer?: timers.Timeout;
-  cooldownResolve?: () => void;
 
   enqueue(source: QueueSource, description: string, epoch: number, run: () => Promise<void>) {
     const duplicate =
@@ -506,17 +509,8 @@ class QueueCheckQueue {
 
   reset() {
     _.forEach(this.jobs.splice(0), job => {job.resolve();});
-    this.cancelCooldown();
-  }
-
-  cancelCooldown() {
     this.previousDuration = 0;
     this.previousFinishedAt = 0;
-    this.cooldownTimer?.clear();
-    this.cooldownTimer = undefined;
-    const resolve = this.cooldownResolve;
-    this.cooldownResolve = undefined;
-    resolve?.();
   }
 
   async drain() {
@@ -531,15 +525,13 @@ class QueueCheckQueue {
         }
 
         // Don't exceed a 50% duty cycle.
-        const minimumStart = this.previousFinishedAt + this.previousDuration;
+        const minimumStart =
+          this.previousFinishedAt + getQueueCheckCooldown(this.previousDuration);
         const now = performance.now();
         if (minimumStart > now) {
           await new Promise<void>(resolve => {
-            this.cooldownResolve = resolve;
-            this.cooldownTimer = timers.setTimeout(resolve, minimumStart - now);
+            timers.setTimeout(resolve, minimumStart - now);
           });
-          this.cooldownTimer = undefined;
-          this.cooldownResolve = undefined;
         }
 
         if (!job.source.isCurrent(job.epoch)) {
@@ -557,10 +549,8 @@ class QueueCheckQueue {
             {description: job.description});
         } finally {
           const finishedAt = performance.now();
-          if (job.source.isCurrent(job.epoch)) {
-            this.previousDuration = finishedAt - start;
-            this.previousFinishedAt = finishedAt;
-          }
+          this.previousDuration = finishedAt - start;
+          this.previousFinishedAt = finishedAt;
           this.active = undefined;
           job.resolve();
         }
@@ -702,7 +692,6 @@ class QueueSource {
       this.connectionStartedAt = performance.now();
       void this.enqueueStartup(epoch);
     } else {
-      queueCheckQueue.cancelCooldown();
       this.activeListener?.stop();
       this.activeListener = undefined;
       this.clearTasks();

--- a/src/firelease.ts
+++ b/src/firelease.ts
@@ -484,6 +484,8 @@ class QueueCheckQueue {
   draining = false;
   previousDuration = 0;
   previousFinishedAt = 0;
+  cooldownTimer?: timers.Timeout;
+  cooldownResolve?: () => void;
 
   enqueue(source: QueueSource, description: string, epoch: number, run: () => Promise<void>) {
     const duplicate =
@@ -504,8 +506,17 @@ class QueueCheckQueue {
 
   reset() {
     _.forEach(this.jobs.splice(0), job => {job.resolve();});
+    this.cancelCooldown();
+  }
+
+  cancelCooldown() {
     this.previousDuration = 0;
     this.previousFinishedAt = 0;
+    this.cooldownTimer?.clear();
+    this.cooldownTimer = undefined;
+    const resolve = this.cooldownResolve;
+    this.cooldownResolve = undefined;
+    resolve?.();
   }
 
   async drain() {
@@ -524,8 +535,11 @@ class QueueCheckQueue {
         const now = performance.now();
         if (minimumStart > now) {
           await new Promise<void>(resolve => {
-            timers.setTimeout(resolve, minimumStart - now);
+            this.cooldownResolve = resolve;
+            this.cooldownTimer = timers.setTimeout(resolve, minimumStart - now);
           });
+          this.cooldownTimer = undefined;
+          this.cooldownResolve = undefined;
         }
 
         if (!job.source.isCurrent(job.epoch)) {
@@ -543,8 +557,10 @@ class QueueCheckQueue {
             {description: job.description});
         } finally {
           const finishedAt = performance.now();
-          this.previousDuration = finishedAt - start;
-          this.previousFinishedAt = finishedAt;
+          if (job.source.isCurrent(job.epoch)) {
+            this.previousDuration = finishedAt - start;
+            this.previousFinishedAt = finishedAt;
+          }
           this.active = undefined;
           job.resolve();
         }
@@ -650,6 +666,7 @@ class QueueSource {
   epoch = 0;
   connected = false;
   crashing = false;
+  connectionStartedAt = 0;
   activeListener?: QueueListener;
   checkTimer?: timers.Timeout;
   demotionTimer?: timers.Timeout;
@@ -682,8 +699,10 @@ class QueueSource {
     this.cancelPendingWork();
     if (connected) {
       this.stats.healthy = true;
+      this.connectionStartedAt = performance.now();
       void this.enqueueStartup(epoch);
     } else {
+      queueCheckQueue.cancelCooldown();
       this.activeListener?.stop();
       this.activeListener = undefined;
       this.clearTasks();
@@ -721,7 +740,10 @@ class QueueSource {
       const loadedMode = await this.loadListener(targetMode, epoch, 'startup');
       if (!loadedMode) return;
       const loadedTaskCount = this.activeListener?.snapshots.size ?? 0;
-      console.log(`Queue worker ${this.ref} loaded ${loadedTaskCount} tasks in ${loadedMode} mode`);
+      const connectionDuration = Math.round(performance.now() - this.connectionStartedAt);
+      console.log(
+        `Queue worker ${this.ref} loaded ${loadedTaskCount} tasks in ${loadedMode} mode` +
+        ` (${ms(connectionDuration)})`);
       if (loadedMode === 'safe') this.scheduleSafeCheck();
       this.initialStartupComplete = true;
     } catch (e) {

--- a/tests/adaptive_buffering.test.ts
+++ b/tests/adaptive_buffering.test.ts
@@ -204,3 +204,42 @@ test('a promotion re-arms a replayed working task after it finishes', async () =
     TESTABLES.resetBetweenTests();
   }
 });
+
+test('disconnect cancels the queue check cooldown', async () => {
+  TESTABLES.resetBetweenTests();
+  const originalConsoleLog = console.log;
+  const logMessages: string[] = [];
+  console.log = (...args: unknown[]) => {logMessages.push(args.map(String).join(' '));};
+  try {
+    firelease.settings.safeQueueSize = 10;
+    firelease.settings.queueCheckInterval = '30d';
+    firelease.settings.globalMaxConcurrent = 0;
+
+    const slowSource = new FakeQueueRef('slow-startup-database', 'queues/slow-startup');
+    slowSource.deferNextValue = true;
+    firelease.attachWorker(asNodeFire(slowSource), {bufferSize: Infinity}, () => undefined);
+    await waitFor(() => slowSource.deferredValueCallbacks.length === 1);
+    await new Promise(resolve => {setTimeout(resolve, 500);});
+    slowSource.releaseDeferredValues();
+    await waitFor(() => logMessages.some(message => message.includes(slowSource.toString())));
+
+    const connectionLog = logMessages.find(message => message.includes(slowSource.toString()))!;
+    assert.match(connectionLog, /loaded 0 tasks in full mode \(\S+\)$/);
+
+    const reconnectingSource =
+      new FakeQueueRef('reconnecting-database', 'queues/reconnecting');
+    reconnectingSource.databaseRoot.connected = false;
+    firelease.attachWorker(
+      asNodeFire(reconnectingSource), {bufferSize: Infinity}, () => undefined);
+    reconnectingSource.databaseRoot.setConnected(true);
+    await new Promise(resolve => {setTimeout(resolve, 25);});
+    assert.strictEqual(reconnectingSource.childrenKeysCalls, 0);
+
+    reconnectingSource.databaseRoot.setConnected(false);
+    reconnectingSource.databaseRoot.setConnected(true);
+    await waitFor(() => reconnectingSource.childrenKeysCalls === 1, 250);
+  } finally {
+    console.log = originalConsoleLog;
+    TESTABLES.resetBetweenTests();
+  }
+});

--- a/tests/adaptive_buffering.test.ts
+++ b/tests/adaptive_buffering.test.ts
@@ -205,7 +205,7 @@ test('a promotion re-arms a replayed working task after it finishes', async () =
   }
 });
 
-test('disconnect cancels the queue check cooldown', async () => {
+test('queue check cooldowns are capped and survive disconnects', async () => {
   TESTABLES.resetBetweenTests();
   const originalConsoleLog = console.log;
   const logMessages: string[] = [];
@@ -214,6 +214,7 @@ test('disconnect cancels the queue check cooldown', async () => {
     firelease.settings.safeQueueSize = 10;
     firelease.settings.queueCheckInterval = '30d';
     firelease.settings.globalMaxConcurrent = 0;
+    assert.strictEqual(TESTABLES.getQueueCheckCooldown(60_000), 30_000);
 
     const slowSource = new FakeQueueRef('slow-startup-database', 'queues/slow-startup');
     slowSource.deferNextValue = true;
@@ -237,7 +238,9 @@ test('disconnect cancels the queue check cooldown', async () => {
 
     reconnectingSource.databaseRoot.setConnected(false);
     reconnectingSource.databaseRoot.setConnected(true);
-    await waitFor(() => reconnectingSource.childrenKeysCalls === 1, 250);
+    await new Promise(resolve => {setTimeout(resolve, 100);});
+    assert.strictEqual(reconnectingSource.childrenKeysCalls, 0);
+    await waitFor(() => reconnectingSource.childrenKeysCalls === 1);
   } finally {
     console.log = originalConsoleLog;
     TESTABLES.resetBetweenTests();


### PR DESCRIPTION
## Summary

- cap the shared queue-check cooldown at 30 seconds
- preserve cooldown debt across disconnects and for stale or crashing jobs
- include elapsed connection time in queue load logs
- bump the package version to 4.3.1

## Why

The shared check queue enforces a maximum 50% duty cycle by delaying the next job for the duration of the previous one. An unexpectedly slow probe or listener load could therefore leave every queue source waiting for an unbounded period during reconnect startup.

Canceling that cooldown on disconnect was too broad because the check queue is process-global: one flapping Firebase database would erase pacing for unrelated healthy sources. Bounding the enforced delay instead preserves global throttling while ensuring that a single abnormal job cannot stall subsequent queue initialization for more than 30 seconds.

## Impact

Normal checks continue to receive an equal-duration cooldown. Checks longer than 30 seconds receive a 30-second cooldown, and disconnects do not allow unrelated sources to bypass it. Queue load logs expose the complete connection duration, including scheduler wait, size probe, and listener loading time.

## Validation

- `yarn test`
- `yarn lint`
- `yarn check-types`
- `yarn build`
- `yarn pack --dry-run`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/firelease/23)
<!-- Reviewable:end -->
